### PR TITLE
call: fix URI encoding in call_connect

### DIFF
--- a/src/call.c
+++ b/src/call.c
@@ -1029,20 +1029,25 @@ int call_connect(struct call *call, const struct pl *paddr)
 	call->peer_uri = mem_deref(call->peer_uri);
 	if (0 == sip_addr_decode(&addr, paddr)) {
 
+		uri_header_get(&addr.uri.headers, &rname, &rval);
+		if (pl_isset(&rval))
+			err = re_sdprintf(&call->replaces, "%H",
+					  uri_header_unescape, &rval);
+
+		if (pl_isset(&addr.uri.headers))
+			addr.uri.headers.l = 0;
+
 		if (pl_isset(&addr.params)) {
-			err = re_sdprintf(&call->peer_uri, "%r%r",
-					  &addr.auri, &addr.params);
+			err = re_sdprintf(&call->peer_uri, "%H%r", uri_encode,
+					  &addr.uri, &addr.params);
 		}
 		else {
-			err = pl_strdup(&call->peer_uri, &addr.auri);
+			err = re_sdprintf(&call->peer_uri, "%H", uri_encode,
+					  &addr.uri);
 		}
 
 		if (pl_isset(&addr.dname))
 			pl_strdup(&call->peer_name, &addr.dname);
-
-		uri_header_get(&addr.uri.headers, &rname, &rval);
-		if (pl_isset(&rval))
-			err = re_sdprintf(&call->replaces, "%r",&rval);
 
 	}
 	else {


### PR DESCRIPTION
According to RFC 3261 section 19.1.1. (Table 1), headers MUST NOT be present in a Request URI. Further, the URI in the Replaces header must be unescaped.